### PR TITLE
Add program requirements parsing and optional-course UI with session integration

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,6 +42,38 @@ def inject_supabase_config():
         supabase_key=SUPABASE_KEY # important to pass the key and not service_role_key
     )
 
+
+
+def rebuild_requirements_from_details(details):
+    buckets = {}
+    for code, course in (details or {}).items():
+        bucket_id = course.get("requirement_bucket")
+        if not bucket_id:
+            continue
+        bucket = buckets.setdefault(bucket_id, {
+            "id": bucket_id,
+            "title": course.get("requirement_bucket_title") or bucket_id,
+            "category": course.get("category", "CORE"),
+            "min_credits": course.get("requirement_min_credits", 0),
+            "max_credits": course.get("requirement_max_credits"),
+            "courses": [],
+        })
+        bucket["courses"].append(code)
+    return {"buckets": list(buckets.values())}
+
+
+def merge_program_requirements(current, incoming):
+    merged = dict(current or {})
+    existing_buckets = {bucket.get("id"): bucket for bucket in merged.get("buckets", [])}
+    for bucket in (incoming or {}).get("buckets", []):
+        bucket_id = bucket.get("id")
+        if not bucket_id or bucket_id in existing_buckets:
+            continue
+        existing_buckets[bucket_id] = bucket
+    merged["buckets"] = list(existing_buckets.values())
+    merged["course_to_bucket"] = {**(current or {}).get("course_to_bucket", {}), **(incoming or {}).get("course_to_bucket", {})}
+    return merged
+
 courses_info = {}
 with open('static/json/courses_info.json', 'r', encoding='utf-8') as f:
     courses_info = json.load(f)
@@ -89,6 +121,7 @@ def scrape_form():
                 #Saving to session
                 session['prereqs_data'] = prereqs_data
                 session['details_data'] = details_data
+                session['program_requirements'] = rebuild_requirements_from_details(details_data)
                 session['graph_data_available'] = True
 
                 return redirect("graph")
@@ -97,11 +130,23 @@ def scrape_form():
     major = request.args.get("programSearch")
     
     if action == "Visualize Program": 
-        courses_prereqs_data, processed_details_data = get_information_for_major.process_program_data(url, major) #scrape the major's site and grab all info
+        program_data = get_information_for_major.process_program_data(url, major)
+        if not isinstance(program_data, tuple):
+            return render_template('scrape_form.html', error="Unable to scrape that program. Please try again later.")
+
+        if len(program_data) == 2:
+            courses_prereqs_data, processed_details_data = program_data
+            requirements_data = {}
+        else:
+            courses_prereqs_data, processed_details_data, requirements_data = program_data #scrape the major's site and grab all info
+        if courses_prereqs_data is None or processed_details_data is None:
+            return render_template('scrape_form.html', error="Unable to scrape that program. Please try again later.")
         
         #Saving the variable to session
         session['prereqs_data'] = courses_prereqs_data
         session['details_data'] = processed_details_data
+        session['program_requirements'] = requirements_data or {}
+        session['credit_requirements'] = (requirements_data or {}).get('credit_requirements', {'core': 0, 'comp': 0, 'elec': 0})
         session['graph_data_available'] = True
 
         return redirect("graph")
@@ -113,6 +158,7 @@ def scrape_form():
             session.pop('prereqs_data', None)
             session.pop('details_data', None)
             session.pop('graph_data_available', None)
+            session.pop('program_requirements', None)
             # This is an initial GET request to the form
             return render_template('scrape_form.html')
         else:
@@ -127,7 +173,8 @@ def graph():
         prereqs = session.get('prereqs_data', {})
         details = session.get('details_data', {})
         logging.log_entry(request, "displaying graph")
-        return render_template('graph.html', prereqs=prereqs, details=details)
+        requirements = session.get('program_requirements') or rebuild_requirements_from_details(details)
+        return render_template('graph.html', prereqs=prereqs, details=details, requirements=requirements)
     else:
         # If no data, redirect back to home page
         return redirect(url_for('scrape_form'))
@@ -151,7 +198,14 @@ def add_program_to_graph():
         logging.log_entry(request, f"adding program {new_program_name} (url: {new_program_url}) to graph")    
 
         # Fetch and process data for the new program
-        new_prereqs, new_details = get_information_for_major.process_program_data(new_program_url, new_program_name)
+        new_program_data = get_information_for_major.process_program_data(new_program_url, new_program_name)
+        if len(new_program_data) == 2:
+            new_prereqs, new_details = new_program_data
+            new_requirements = {}
+        else:
+            new_prereqs, new_details, new_requirements = new_program_data
+        if new_prereqs is None or new_details is None:
+            raise ValueError("Unable to scrape that program.")
 
         # Retrieve current graph data from session
         current_prereqs = session.get('prereqs_data', {})
@@ -174,6 +228,7 @@ def add_program_to_graph():
 
         session['details_data'].update(new_details)
         session['prereqs_data'].update(new_prereqs)
+        session['program_requirements'] = merge_program_requirements(session.get('program_requirements', {}), new_requirements or {})
         session['graph_data_available'] = True
 
         # NEW: If JavaScript asked for this, send the raw JSON data back!
@@ -181,7 +236,8 @@ def add_program_to_graph():
             return jsonify({
                 "status": "success", 
                 "new_details": new_details, 
-                "new_prereqs": new_prereqs
+                "new_prereqs": new_prereqs,
+                "new_requirements": new_requirements or {}
             })
 
         return redirect(url_for('graph'))
@@ -394,6 +450,7 @@ def load_graph():
             # Load the data into the Flask session
             session['prereqs_data'] = graph.get('prereqs_data', {})
             session['details_data'] = graph.get('details_data', {})
+            session['program_requirements'] = rebuild_requirements_from_details(session['details_data'])
             session['schedule_id'] = graph.get('id')
             session['graph_data_available'] = True
             

--- a/scripts/Getting_Info_For_Major/get_courses_of_major.py
+++ b/scripts/Getting_Info_For_Major/get_courses_of_major.py
@@ -24,7 +24,7 @@ def get_program_codes(url, soup=None):
 
     # On McGill pages, program course rows use <td class="codecol">COMP 250</td>.
     course_codes = soup.find_all("td", class_="codecol")
-    return [code.get_text(strip=True).replace(" ", "") for code in course_codes]
+    return [code.get_text(strip=True) for code in course_codes]
 
 
 def get_course_metadata_from_program_page(code, soup):
@@ -33,39 +33,53 @@ def get_course_metadata_from_program_page(code, soup):
     This is only a fallback for courses missing from static/json/courses_info.json.
     It does NOT replace the Gemini prerequisite pipeline.
     """
-    normalized_code = code.replace(" ", "")
-    code_cell = soup.find("td", class_="codecol", string=lambda txt: txt and normalized_code in txt.replace(" ", ""))
+    # Locate the correct code cell
+    code_cell = soup.find("td", class_="codecol", string=lambda txt: txt and code in txt)
     if not code_cell:
         for candidate in soup.find_all("td", class_="codecol"):
-            text = candidate.get_text(" ", strip=True).replace(" ", "")
-            if text == normalized_code:
+            if candidate.get_text(strip=True) == code:
                 code_cell = candidate
                 break
 
     if not code_cell:
         return None
 
+    # Get the parent row of the code cell
     row = code_cell.find_parent("tr")
     if not row:
         return None
 
-    row_text = row.get_text(" ", strip=True)
     title = ""
-    title_cell = row.find("td", class_=lambda cls: cls and ("titlecol" in cls or "courseblocktitle" in cls))
-    if title_cell:
-        title = title_cell.get_text(" ", strip=True)
-    else:
-        code_match = COURSE_CODE_RE.search(row_text)
-        if code_match:
-            title = row_text[code_match.end():].strip(" -:")
-
     credits = "N/A"
-    credit_match = re.search(r"(\d+(?:\.\d+)?)\s*credits?", row_text, re.IGNORECASE)
-    if credit_match:
-        credits = credit_match.group(1)
+    semesters_offered = "Unknown"
+
+    # Extract Title
+    title_cell = code_cell.find_next_sibling("td")
+    if title_cell:
+        title = title_cell.get_text(strip=True).rstrip(".")
+
+    # Extract Credits
+    if title_cell:
+        hours_cell = title_cell.find_next_sibling("td")
+        if hours_cell:
+            hours_text = hours_cell.get_text(strip=True)
+            credit_match = re.search(r"(\d+(?:\.\d+)?)", hours_text)
+            if credit_match:
+                credits = credit_match.group(1)
+
+    # Extract Semesters Offered from the adjacent bubbledrawer row
+    # find_next_sibling find the next <tr> tag directly below the current course row
+    drawer_row = row.find_next_sibling("tr", class_="bubbledrawer")
+    if drawer_row:
+        terms_paragraph = drawer_row.find("p", class_="bubbledrawer__terms")
+        if terms_paragraph:
+            # Extract text and strip out the "Terms offered:" prefix label
+            raw_terms = terms_paragraph.get_text(" ", strip=True)
+            semesters_offered = raw_terms.replace("Terms offered:", "").strip().strip('"')
 
     return {
-        "title": title or f"{normalized_code} (Details not found)",
+        "code": code,
+        "title": title or f"{code} (Details not found)",
         "credits": credits,
-        "semesters_offered": "Unknown",
+        "semesters_offered": semesters_offered,
     }

--- a/scripts/Getting_Info_For_Major/get_courses_of_major.py
+++ b/scripts/Getting_Info_For_Major/get_courses_of_major.py
@@ -1,24 +1,71 @@
+import re
 import requests
 from bs4 import BeautifulSoup
 
-#Given url of the major, it scrapes the site and gets all the courses of the major.
-#Eventually this could be ran on all programs and be hard-coded instead of running on every query
+# Given url of the major, it scrapes the site and gets all the courses of the major.
+# Eventually this could be run on all programs and be hard-coded instead of running on every query.
 
-def get_program_codes(url):
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+}
 
-    #Passing a header to mimic a real user instead
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-    }
+COURSE_CODE_RE = re.compile(r"\b[A-Z]{3,5}\s?\d{3}[A-Z0-9]?\b")
 
-    res = requests.get(url, headers=headers)
-    soup = BeautifulSoup(res.text, 'html.parser')
 
-    #finding all required courses: 
+def get_program_soup(url):
+    # Passing a header to mimic a real user instead.
+    res = requests.get(url, headers=HEADERS)
+    res.raise_for_status()
+    return BeautifulSoup(res.text, "html.parser")
+
+
+def get_program_codes(url, soup=None):
+    soup = soup or get_program_soup(url)
+
+    # On McGill pages, program course rows use <td class="codecol">COMP 250</td>.
     course_codes = soup.find_all("td", class_="codecol")
-    course_codes = [code.get_text(strip=True) for code in course_codes]
-    
-    return course_codes
+    return [code.get_text(strip=True).replace(" ", "") for code in course_codes]
 
-    
-    
+
+def get_course_metadata_from_program_page(code, soup):
+    """Best-effort extraction of title/credits/terms from a program page table row.
+
+    This is only a fallback for courses missing from static/json/courses_info.json.
+    It does NOT replace the Gemini prerequisite pipeline.
+    """
+    normalized_code = code.replace(" ", "")
+    code_cell = soup.find("td", class_="codecol", string=lambda txt: txt and normalized_code in txt.replace(" ", ""))
+    if not code_cell:
+        for candidate in soup.find_all("td", class_="codecol"):
+            text = candidate.get_text(" ", strip=True).replace(" ", "")
+            if text == normalized_code:
+                code_cell = candidate
+                break
+
+    if not code_cell:
+        return None
+
+    row = code_cell.find_parent("tr")
+    if not row:
+        return None
+
+    row_text = row.get_text(" ", strip=True)
+    title = ""
+    title_cell = row.find("td", class_=lambda cls: cls and ("titlecol" in cls or "courseblocktitle" in cls))
+    if title_cell:
+        title = title_cell.get_text(" ", strip=True)
+    else:
+        code_match = COURSE_CODE_RE.search(row_text)
+        if code_match:
+            title = row_text[code_match.end():].strip(" -:")
+
+    credits = "N/A"
+    credit_match = re.search(r"(\d+(?:\.\d+)?)\s*credits?", row_text, re.IGNORECASE)
+    if credit_match:
+        credits = credit_match.group(1)
+
+    return {
+        "title": title or f"{normalized_code} (Details not found)",
+        "credits": credits,
+        "semesters_offered": "Unknown",
+    }

--- a/scripts/Getting_Info_For_Major/get_information_for_major.py
+++ b/scripts/Getting_Info_For_Major/get_information_for_major.py
@@ -1,4 +1,4 @@
-from scripts.Getting_Info_For_Major import get_courses_of_major, get_prereqs
+from scripts.Getting_Info_For_Major import get_courses_of_major, get_prereqs, program_requirements
 from scripts import utils
 import json
 
@@ -15,10 +15,12 @@ with open('static/json/honours_matches.json', 'r', encoding='utf-8') as f:
 
 def process_program_data(program_url, major):
     try:
-        course_codes = get_courses_of_major.get_program_codes(program_url)
+        program_soup = get_courses_of_major.get_program_soup(program_url)
+        course_codes = get_courses_of_major.get_program_codes(program_url, soup=program_soup)
+        requirements_data = program_requirements.extract_program_requirements(program_soup)
         if not course_codes:
             print(f"No course codes found for URL: {program_url}")
-            return None, None
+            return None, None, None
 
         course_details_data = {}
         gemini_data = {}
@@ -37,8 +39,8 @@ def process_program_data(program_url, major):
                 }
             else:
                 print(f"Warning: Course code {code} from program {major} not found in global courses_info.json")
-                # Add a placeholder if not found in global courses_info
-                course_details_data[code] = {
+                fallback_metadata = get_courses_of_major.get_course_metadata_from_program_page(code, program_soup)
+                course_details_data[code] = fallback_metadata or {
                     "title": f"{code} (Details not found)",
                     "credits": "N/A",
                     "semesters_offered": "Unknown",
@@ -58,8 +60,18 @@ def process_program_data(program_url, major):
         for code, details in course_details_data.items():
             default_detail = {"title": "Unknown Title", "credits": "N/A", "semesters_offered": "Unknown"}
             actual_details = {**default_detail, **details}
+            bucket_id = requirements_data.get("course_to_bucket", {}).get(code)
+            bucket = next(
+                (bucket for bucket in requirements_data.get("buckets", []) if bucket.get("id") == bucket_id),
+                None,
+            )
             course_details_full[code] = {
                 **actual_details,
+                "category": bucket.get("category", "CORE") if bucket else "CORE",
+                "requirement_bucket": bucket_id,
+                "requirement_bucket_title": bucket.get("title") if bucket else None,
+                "requirement_min_credits": bucket.get("min_credits") if bucket else 0,
+                "requirement_max_credits": bucket.get("max_credits") if bucket else None,
                 "color": utils.parse_semester_to_color(actual_details.get("semesters_offered", ""))
             }
 
@@ -99,7 +111,7 @@ def process_program_data(program_url, major):
                         course_details_full[prereq_code] = {"title": "Details Not Found (Prereq)", "credits": "N/A", "semesters_offered": "Unknown", "color": "LightSteelBlue"}
 
 
-        return courses_prereqs_data, course_details_full
+        return courses_prereqs_data, course_details_full, requirements_data
     except Exception as e:
         print(f"Error in process_program_data for {program_url}: {e}")
-        return None, None
+        return None, None, None

--- a/scripts/Getting_Info_For_Major/get_information_for_major.py
+++ b/scripts/Getting_Info_For_Major/get_information_for_major.py
@@ -72,6 +72,7 @@ def process_program_data(program_url, major):
                 "requirement_bucket_title": bucket.get("title") if bucket else None,
                 "requirement_min_credits": bucket.get("min_credits") if bucket else 0,
                 "requirement_max_credits": bucket.get("max_credits") if bucket else None,
+                "include_in_graph": (bucket.get("category", "CORE") == "CORE") if bucket else True,
                 "color": utils.parse_semester_to_color(actual_details.get("semesters_offered", ""))
             }
 

--- a/scripts/Getting_Info_For_Major/program_requirements.py
+++ b/scripts/Getting_Info_For_Major/program_requirements.py
@@ -1,12 +1,3 @@
-"""Parse McGill program pages into graduation-oriented requirement buckets.
-
-Parser assumptions about McGill course catalogue HTML:
-- Program requirements are rendered under a content root with id="coursestext".
-- Course rows contain <td class="codecol"> cells for course codes.
-- Bucket intent is typically expressed in adjacent headings/captions and often
-  includes ranges like "8-15 credits".
-"""
-
 from __future__ import annotations
 
 import re
@@ -39,89 +30,105 @@ class RequirementBucket:
 
 
 def _clean_text(text: str) -> str:
-    return re.sub(r"\s+", " ", text or "").strip()
+    return re.sub(r"\s+", " ", (text or "")).strip()
 
 
 def _slugify(value: str, fallback: str) -> str:
-    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    value = _clean_text(value).lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", value).strip("-")
     return slug or fallback
 
 
-def _category_from_text(text: str) -> str:
-    normalized = text.lower()
-    if "elective" in normalized:
-        return "ELECTIVE"
-    if "complementary" in normalized or "selected from" in normalized or "choose" in normalized:
+def _category_from_heading(heading: str) -> str:
+    h = heading.lower()
+    if "required" in h:
+        return "CORE"
+    if "complementary" in h:
         return "COMPLEMENTARY"
+    if "elective" in h:
+        return "ELECTIVE"
     return "CORE"
 
 
 def _credit_bounds(text: str) -> tuple[float, float | None]:
+    text = _clean_text(text)
     range_match = CREDIT_RANGE_RE.search(text)
     if range_match:
         return float(range_match.group("min")), float(range_match.group("max"))
-
     single_match = SINGLE_CREDIT_RE.search(text)
     if single_match:
-        credits = float(single_match.group("credits"))
-        return credits, credits
-
+        c = float(single_match.group("credits"))
+        return c, c
     return 0, None
 
 
-def extract_program_requirements(soup) -> dict[str, Any]:
-    buckets: list[RequirementBucket] = []
-    current_heading = "Program Courses"
-
+def extract_program_requirements(soup):
     content_root = soup.find(id="coursestext") or soup.find("main") or soup
-    for element in content_root.find_all(["h2", "h3", "h4", "p", "table"], recursive=True):
-        if element.name in {"h2", "h3", "h4", "p"}:
+
+    buckets: list[RequirementBucket] = []
+    current_section_title = "Program Courses"
+    current_section_category = "CORE"
+    pending_bucket_label = ""
+
+    for element in content_root.find_all(["h2", "p", "div"], recursive=True):
+        if element.name == "h2":
+            current_section_title = _clean_text(element.get_text(" ", strip=True))
+            current_section_category = _category_from_heading(current_section_title)
+            pending_bucket_label = ""
+            continue
+
+        if element.name == "p":
             text = _clean_text(element.get_text(" ", strip=True))
-            if text and ("credit" in text.lower() or element.name in {"h2", "h3", "h4"}):
-                current_heading = text
+            if "credit" in text.lower() and ("selected from" in text.lower() or "choose" in text.lower()):
+                pending_bucket_label = text
             continue
 
-        if not element.find("td", class_=lambda cls: cls and "codecol" in cls):
-            continue
+        if element.name == "div" and "courselist-wrapper" in (element.get("class") or []):
+            table = element.find("table", class_="sc_courselist")
+            if not table:
+                continue
 
-        table_title = _clean_text(element.find("caption").get_text(" ", strip=True)) if element.find("caption") else current_heading
-        min_credits, max_credits = _credit_bounds(table_title)
-        bucket = RequirementBucket(
-            id=_slugify(table_title, f"bucket-{len(buckets) + 1}"),
-            title=table_title or "Program Courses",
-            category=_category_from_text(table_title or ""),
-            min_credits=min_credits,
-            max_credits=max_credits,
-        )
+            bucket_label = pending_bucket_label or current_section_title
+            pending_bucket_label = ""
 
-        for code_cell in element.find_all("td", class_="codecol"):
-            raw = _clean_text(code_cell.get_text(" ", strip=True))
-            match = COURSE_CODE_RE.search(raw)
-            if match:
-                normalized = match.group(0).replace(" ", "")
-                if normalized not in bucket.courses:
-                    bucket.courses.append(normalized)
+            min_credits, max_credits = _credit_bounds(bucket_label)
+            bucket = RequirementBucket(
+                id=_slugify(f"{current_section_title}-{bucket_label}", f"bucket-{len(buckets)+1}"),
+                title=bucket_label,
+                category=current_section_category,
+                min_credits=min_credits,
+                max_credits=max_credits,
+            )
 
-        if bucket.courses:
-            buckets.append(bucket)
+            for row in table.select("tbody > tr"):
+                row_classes = row.get("class") or []
+                if "bubbledrawer" in row_classes:
+                    continue
+                code_cell = row.find("td", class_="codecol")
+                if not code_cell:
+                    continue
+                match = COURSE_CODE_RE.search(_clean_text(code_cell.get_text(" ", strip=True)))
+                if match:
+                    bucket.courses.append(match.group(0).replace(" ", ""))
 
-    course_to_bucket: dict[str, str] = {}
+            if bucket.courses:
+                bucket.courses = list(dict.fromkeys(bucket.courses))
+                buckets.append(bucket)
+
+    course_to_bucket = {}
     totals = {"core": 0.0, "comp": 0.0, "elec": 0.0}
-    for bucket in buckets:
-        for code in bucket.courses:
-            course_to_bucket.setdefault(code, bucket.id)
-
-        if bucket.category == "COMPLEMENTARY":
-            totals["comp"] += bucket.min_credits
-        elif bucket.category == "ELECTIVE":
-            totals["elec"] += bucket.min_credits
+    for b in buckets:
+        for c in b.courses:
+            course_to_bucket.setdefault(c, b.id)
+        if b.category == "CORE":
+            totals["core"] += b.min_credits
+        elif b.category == "COMPLEMENTARY":
+            totals["comp"] += b.min_credits
         else:
-            totals["core"] += bucket.min_credits
-
-    credit_requirements = {k: int(v) if v.is_integer() else v for k, v in totals.items()}
+            totals["elec"] += b.min_credits
 
     return {
-        "buckets": [bucket.to_dict() for bucket in buckets],
+        "buckets": [b.to_dict() for b in buckets],
         "course_to_bucket": course_to_bucket,
-        "credit_requirements": credit_requirements,
+        "credit_requirements": {k: int(v) if v.is_integer() else v for k, v in totals.items()},
     }

--- a/scripts/Getting_Info_For_Major/program_requirements.py
+++ b/scripts/Getting_Info_For_Major/program_requirements.py
@@ -1,0 +1,127 @@
+"""Parse McGill program pages into graduation-oriented requirement buckets.
+
+Parser assumptions about McGill course catalogue HTML:
+- Program requirements are rendered under a content root with id="coursestext".
+- Course rows contain <td class="codecol"> cells for course codes.
+- Bucket intent is typically expressed in adjacent headings/captions and often
+  includes ranges like "8-15 credits".
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+COURSE_CODE_RE = re.compile(r"\b[A-Z]{3,5}\s?\d{3}[A-Z0-9]?\b")
+CREDIT_RANGE_RE = re.compile(r"(?P<min>\d+(?:\.\d+)?)\s*(?:-|–|to)\s*(?P<max>\d+(?:\.\d+)?)\s+credits?", re.IGNORECASE)
+SINGLE_CREDIT_RE = re.compile(r"(?P<credits>\d+(?:\.\d+)?)\s+credits?", re.IGNORECASE)
+
+
+@dataclass
+class RequirementBucket:
+    id: str
+    title: str
+    category: str
+    min_credits: float = 0
+    max_credits: float | None = None
+    courses: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "category": self.category,
+            "min_credits": self.min_credits,
+            "max_credits": self.max_credits,
+            "courses": self.courses,
+        }
+
+
+def _clean_text(text: str) -> str:
+    return re.sub(r"\s+", " ", text or "").strip()
+
+
+def _slugify(value: str, fallback: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or fallback
+
+
+def _category_from_text(text: str) -> str:
+    normalized = text.lower()
+    if "elective" in normalized:
+        return "ELECTIVE"
+    if "complementary" in normalized or "selected from" in normalized or "choose" in normalized:
+        return "COMPLEMENTARY"
+    return "CORE"
+
+
+def _credit_bounds(text: str) -> tuple[float, float | None]:
+    range_match = CREDIT_RANGE_RE.search(text)
+    if range_match:
+        return float(range_match.group("min")), float(range_match.group("max"))
+
+    single_match = SINGLE_CREDIT_RE.search(text)
+    if single_match:
+        credits = float(single_match.group("credits"))
+        return credits, credits
+
+    return 0, None
+
+
+def extract_program_requirements(soup) -> dict[str, Any]:
+    buckets: list[RequirementBucket] = []
+    current_heading = "Program Courses"
+
+    content_root = soup.find(id="coursestext") or soup.find("main") or soup
+    for element in content_root.find_all(["h2", "h3", "h4", "p", "table"], recursive=True):
+        if element.name in {"h2", "h3", "h4", "p"}:
+            text = _clean_text(element.get_text(" ", strip=True))
+            if text and ("credit" in text.lower() or element.name in {"h2", "h3", "h4"}):
+                current_heading = text
+            continue
+
+        if not element.find("td", class_=lambda cls: cls and "codecol" in cls):
+            continue
+
+        table_title = _clean_text(element.find("caption").get_text(" ", strip=True)) if element.find("caption") else current_heading
+        min_credits, max_credits = _credit_bounds(table_title)
+        bucket = RequirementBucket(
+            id=_slugify(table_title, f"bucket-{len(buckets) + 1}"),
+            title=table_title or "Program Courses",
+            category=_category_from_text(table_title or ""),
+            min_credits=min_credits,
+            max_credits=max_credits,
+        )
+
+        for code_cell in element.find_all("td", class_="codecol"):
+            raw = _clean_text(code_cell.get_text(" ", strip=True))
+            match = COURSE_CODE_RE.search(raw)
+            if match:
+                normalized = match.group(0).replace(" ", "")
+                if normalized not in bucket.courses:
+                    bucket.courses.append(normalized)
+
+        if bucket.courses:
+            buckets.append(bucket)
+
+    course_to_bucket: dict[str, str] = {}
+    totals = {"core": 0.0, "comp": 0.0, "elec": 0.0}
+    for bucket in buckets:
+        for code in bucket.courses:
+            course_to_bucket.setdefault(code, bucket.id)
+
+        if bucket.category == "COMPLEMENTARY":
+            totals["comp"] += bucket.min_credits
+        elif bucket.category == "ELECTIVE":
+            totals["elec"] += bucket.min_credits
+        else:
+            totals["core"] += bucket.min_credits
+
+    credit_requirements = {k: int(v) if v.is_integer() else v for k, v in totals.items()}
+
+    return {
+        "buckets": [bucket.to_dict() for bucket in buckets],
+        "course_to_bucket": course_to_bucket,
+        "credit_requirements": credit_requirements,
+    }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1548,3 +1548,36 @@ button#scrapeButton:disabled {
     transform: translate(-50%, -50%) rotate(360deg);
   }
 }
+
+
+.optional-shelf {
+  margin-left: auto;
+  min-width: 300px;
+  max-width: 380px;
+  background: #fafafa;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 10px;
+}
+.optional-count {
+  color: var(--text-muted);
+  font-size: 0.9em;
+  margin-bottom: 8px;
+}
+.optional-course-list {
+  max-height: 220px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.optional-course-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: center;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 8px;
+  background: #fff;
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1581,3 +1581,41 @@ button#scrapeButton:disabled {
   padding: 8px;
   background: #fff;
 }
+
+
+.optional-bucket {
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: #fff;
+  padding: 8px;
+  margin-bottom: 8px;
+}
+.optional-bucket h5 {
+  margin: 0 0 4px 0;
+  font-size: 0.95rem;
+}
+.optional-bucket-meta {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+.optional-course-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.88rem;
+  padding: 6px 0;
+  border-top: 1px dashed var(--border-color);
+}
+.optional-course-row:first-of-type {
+  border-top: none;
+}
+.secondary-btn {
+  background: #1f2937;
+}
+.danger-btn {
+  background: #b91c1c;
+}
+
+.optional-shelf-title { margin: 0 0 6px 0; }

--- a/static/js/data_init.js
+++ b/static/js/data_init.js
@@ -104,6 +104,7 @@ export function initializeNodes(detailsData, prereqsData) {
   // 2. Build the nodes using the newly calculated X and Y coordinates
   Object.keys(detailsData).forEach((nodeId) => {
     const course = detailsData[nodeId];
+    if (course.include_in_graph === false) return;
 
     nodesArray.push({
       id: nodeId,

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -13,6 +13,7 @@ import { setupSheetViewListeners, updateSheetView } from "./sheet_view.js";
 import { setupSidebar } from "./sidebar.js";
 import { generateNodeLabel, getStatusColor } from "./node_utils.js";
 import { updateGpaTracker } from "./gpa_tracker.js";
+import { setupOptionalCoursesShelf } from "./optional_courses.js";
 
 document.addEventListener("DOMContentLoaded", function () {
   if (
@@ -101,6 +102,7 @@ document.addEventListener("DOMContentLoaded", function () {
     saveGraphState,
     markGraphDirty,
   );
+  setupOptionalCoursesShelf(network, nodes, edges, detailsData, prereqsData, markGraphDirty);
 
   // Core Network Events
   network.on("click", function (params) {

--- a/static/js/optional_courses.js
+++ b/static/js/optional_courses.js
@@ -1,0 +1,112 @@
+import { generateNodeLabel, getStatusColor } from "./node_utils.js";
+
+function isOptionalCourse(course) {
+  const cat = (course.category || "").toUpperCase();
+  const title = (course.requirement_bucket_title || "").toLowerCase();
+  const min = Number(course.requirement_min_credits || 0);
+  const max = Number(course.requirement_max_credits || 0);
+
+  if (cat === "COMPLEMENTARY" || cat === "ELECTIVE") return true;
+  if (max > min && min > 0) return true;
+  return title.includes("choose") || title.includes("selected") || title.includes("complementary") || title.includes("elective");
+}
+
+export function setupOptionalCoursesShelf(network, nodes, edges, detailsData, prereqsData, markGraphDirty) {
+  const listEl = document.getElementById("optionalCourseList");
+  const countEl = document.getElementById("optionalCount");
+  if (!listEl || !countEl) return;
+
+  const hiddenOptionalIds = new Set();
+
+  function syncCount() {
+    countEl.textContent = `${hiddenOptionalIds.size} optional courses hidden`;
+  }
+
+  function restoreEdgesForCourse(courseId) {
+    const edgeUpdates = [];
+    const reqs = prereqsData[courseId] || [];
+    reqs.forEach((fromNode) => {
+      if (nodes.get(fromNode) && nodes.get(courseId)) {
+        edgeUpdates.push({ from: fromNode, to: courseId, arrows: "to" });
+      }
+    });
+
+    Object.keys(prereqsData).forEach((toNode) => {
+      const toReqs = prereqsData[toNode] || [];
+      if (toReqs.includes(courseId) && nodes.get(toNode) && nodes.get(courseId)) {
+        edgeUpdates.push({ from: courseId, to: toNode, arrows: "to" });
+      }
+    });
+
+    if (edgeUpdates.length) edges.update(edgeUpdates);
+  }
+
+  function renderOptionalList() {
+    listEl.innerHTML = "";
+    [...hiddenOptionalIds].sort().forEach((courseId) => {
+      const course = detailsData[courseId];
+      if (!course) return;
+
+      const item = document.createElement("div");
+      item.className = "optional-course-item";
+      item.innerHTML = `<div><strong>${course.code || courseId}</strong><br><small>${course.title || "Untitled"}</small></div>`;
+
+      const addBtn = document.createElement("button");
+      addBtn.textContent = "Add";
+      addBtn.onclick = () => {
+        const d = detailsData[courseId];
+        nodes.add({
+          id: courseId,
+          x: d.x ?? 0,
+          y: d.y ?? 0,
+          label: generateNodeLabel(
+            d.code || courseId,
+            d.title,
+            d.credits,
+            d.semesters_offered,
+            d.category,
+            d.planned_semester,
+            d.status,
+          ),
+          color: getStatusColor(d.status),
+        });
+        restoreEdgesForCourse(courseId);
+        hiddenOptionalIds.delete(courseId);
+        renderOptionalList();
+        markGraphDirty();
+      };
+
+      item.appendChild(addBtn);
+      listEl.appendChild(item);
+    });
+
+    syncCount();
+  }
+
+  Object.keys(detailsData).forEach((courseId) => {
+    const course = detailsData[courseId];
+    if (!course || !isOptionalCourse(course)) return;
+    if (!nodes.get(courseId)) return;
+
+    hiddenOptionalIds.add(courseId);
+    nodes.remove(courseId);
+  });
+
+  renderOptionalList();
+
+  const hideBtn = document.getElementById("hideSelectedOptionalBtn");
+  if (hideBtn) {
+    hideBtn.onclick = () => {
+      const selected = network.getSelectedNodes();
+      selected.forEach((courseId) => {
+        const course = detailsData[courseId];
+        if (course && isOptionalCourse(course)) {
+          hiddenOptionalIds.add(courseId);
+          nodes.remove(courseId);
+        }
+      });
+      renderOptionalList();
+      markGraphDirty();
+    };
+  }
+}

--- a/static/js/optional_courses.js
+++ b/static/js/optional_courses.js
@@ -1,112 +1,100 @@
 import { generateNodeLabel, getStatusColor } from "./node_utils.js";
+import { updateSheetView } from "./sheet_view.js";
 
-function isOptionalCourse(course) {
-  const cat = (course.category || "").toUpperCase();
-  const title = (course.requirement_bucket_title || "").toLowerCase();
-  const min = Number(course.requirement_min_credits || 0);
-  const max = Number(course.requirement_max_credits || 0);
+function ensureBucketCourseData(requirements, detailsData) {
+  if (!requirements?.buckets) return;
+  requirements.buckets.forEach((bucket) => {
+    bucket.courses = (bucket.courses || []).filter((id) => detailsData[id]);
+  });
+}
 
-  if (cat === "COMPLEMENTARY" || cat === "ELECTIVE") return true;
-  if (max > min && min > 0) return true;
-  return title.includes("choose") || title.includes("selected") || title.includes("complementary") || title.includes("elective");
+function renderCourse(network, nodes, edges, detailsData, prereqsData, courseId) {
+  if (nodes.get(courseId) || !detailsData[courseId]) return;
+  const d = detailsData[courseId];
+  nodes.add({
+    id: courseId,
+    x: d.x ?? 0,
+    y: d.y ?? 0,
+    label: generateNodeLabel(d.code || courseId, d.title, d.credits, d.semesters_offered, d.category, d.planned_semester, d.status),
+    color: getStatusColor(d.status),
+  });
+  d.include_in_graph = true;
+
+  const newEdges = [];
+  (prereqsData[courseId] || []).forEach((fromNode) => {
+    if (nodes.get(fromNode)) newEdges.push({ from: fromNode, to: courseId, arrows: "to" });
+  });
+  Object.entries(prereqsData).forEach(([toNode, reqs]) => {
+    if (Array.isArray(reqs) && reqs.includes(courseId) && nodes.get(toNode)) {
+      newEdges.push({ from: courseId, to: toNode, arrows: "to" });
+    }
+  });
+  if (newEdges.length) edges.update(newEdges);
 }
 
 export function setupOptionalCoursesShelf(network, nodes, edges, detailsData, prereqsData, markGraphDirty) {
-  const listEl = document.getElementById("optionalCourseList");
-  const countEl = document.getElementById("optionalCount");
-  if (!listEl || !countEl) return;
+  const root = document.getElementById("optionalCourseShelf");
+  const list = document.getElementById("optionalBucketList");
+  if (!root || !list) return;
 
-  const hiddenOptionalIds = new Set();
+  const requirements = window.programRequirements || { buckets: [] };
+  ensureBucketCourseData(requirements, detailsData);
 
-  function syncCount() {
-    countEl.textContent = `${hiddenOptionalIds.size} optional courses hidden`;
-  }
-
-  function restoreEdgesForCourse(courseId) {
-    const edgeUpdates = [];
-    const reqs = prereqsData[courseId] || [];
-    reqs.forEach((fromNode) => {
-      if (nodes.get(fromNode) && nodes.get(courseId)) {
-        edgeUpdates.push({ from: fromNode, to: courseId, arrows: "to" });
-      }
-    });
-
-    Object.keys(prereqsData).forEach((toNode) => {
-      const toReqs = prereqsData[toNode] || [];
-      if (toReqs.includes(courseId) && nodes.get(toNode) && nodes.get(courseId)) {
-        edgeUpdates.push({ from: courseId, to: toNode, arrows: "to" });
-      }
-    });
-
-    if (edgeUpdates.length) edges.update(edgeUpdates);
-  }
-
-  function renderOptionalList() {
-    listEl.innerHTML = "";
-    [...hiddenOptionalIds].sort().forEach((courseId) => {
-      const course = detailsData[courseId];
-      if (!course) return;
-
-      const item = document.createElement("div");
-      item.className = "optional-course-item";
-      item.innerHTML = `<div><strong>${course.code || courseId}</strong><br><small>${course.title || "Untitled"}</small></div>`;
-
-      const addBtn = document.createElement("button");
-      addBtn.textContent = "Add";
-      addBtn.onclick = () => {
-        const d = detailsData[courseId];
-        nodes.add({
-          id: courseId,
-          x: d.x ?? 0,
-          y: d.y ?? 0,
-          label: generateNodeLabel(
-            d.code || courseId,
-            d.title,
-            d.credits,
-            d.semesters_offered,
-            d.category,
-            d.planned_semester,
-            d.status,
-          ),
-          color: getStatusColor(d.status),
-        });
-        restoreEdgesForCourse(courseId);
-        hiddenOptionalIds.delete(courseId);
-        renderOptionalList();
-        markGraphDirty();
-      };
-
-      item.appendChild(addBtn);
-      listEl.appendChild(item);
-    });
-
-    syncCount();
-  }
-
-  Object.keys(detailsData).forEach((courseId) => {
-    const course = detailsData[courseId];
-    if (!course || !isOptionalCourse(course)) return;
-    if (!nodes.get(courseId)) return;
-
-    hiddenOptionalIds.add(courseId);
-    nodes.remove(courseId);
+  // initial state: keep only required/core courses on graph
+  Object.entries(detailsData).forEach(([id, c]) => {
+    if (c.include_in_graph === false && nodes.get(id)) nodes.remove(id);
   });
 
-  renderOptionalList();
+  function render() {
+    list.innerHTML = "";
+    const buckets = requirements.buckets || [];
+    if (!buckets.length) {
+      root.style.display = "none";
+      return;
+    }
+    root.style.display = "block";
 
-  const hideBtn = document.getElementById("hideSelectedOptionalBtn");
-  if (hideBtn) {
-    hideBtn.onclick = () => {
-      const selected = network.getSelectedNodes();
-      selected.forEach((courseId) => {
-        const course = detailsData[courseId];
-        if (course && isOptionalCourse(course)) {
-          hiddenOptionalIds.add(courseId);
-          nodes.remove(courseId);
-        }
+    buckets.forEach((bucket) => {
+      if ((bucket.category || "CORE") === "CORE" && Number(bucket.max_credits || 0) === 0) {
+        return;
+      }
+
+      const wrapper = document.createElement("div");
+      wrapper.className = "optional-bucket";
+      const inGraphCredits = (bucket.courses || []).reduce((sum, id) => {
+        const c = detailsData[id];
+        return c && c.include_in_graph ? sum + (parseFloat(c.credits) || 0) : sum;
+      }, 0);
+      wrapper.innerHTML = `<h5>${bucket.title}</h5><div class="optional-bucket-meta">${bucket.category} • Added ${inGraphCredits}/${bucket.min_credits}${bucket.max_credits ? `-${bucket.max_credits}` : ""} credits</div>`;
+
+      (bucket.courses || []).forEach((courseId) => {
+        const c = detailsData[courseId];
+        if (!c) return;
+        const row = document.createElement("div");
+        row.className = "optional-course-row";
+        const isOnGraph = !!c.include_in_graph;
+        row.innerHTML = `<span><strong>${c.code || courseId}</strong> ${c.title} (${c.credits})</span>`;
+        const btn = document.createElement("button");
+        btn.textContent = isOnGraph ? "Remove" : "Add";
+        btn.className = isOnGraph ? "danger-btn" : "secondary-btn";
+        btn.onclick = () => {
+          if (isOnGraph) {
+            c.include_in_graph = false;
+            if (nodes.get(courseId)) nodes.remove(courseId);
+          } else {
+            renderCourse(network, nodes, edges, detailsData, prereqsData, courseId);
+          }
+          markGraphDirty();
+          updateSheetView(detailsData, requirements);
+          render();
+        };
+        row.appendChild(btn);
+        wrapper.appendChild(row);
       });
-      renderOptionalList();
-      markGraphDirty();
-    };
+
+      list.appendChild(wrapper);
+    });
   }
+
+  render();
 }

--- a/static/js/program_handler.js
+++ b/static/js/program_handler.js
@@ -62,6 +62,13 @@ export function setupAddProgramButton(
               // 2. Update local memory
               Object.assign(detailsData, result.new_details);
               Object.assign(prereqsData, result.new_prereqs);
+              if (result.new_requirements?.buckets) {
+                window.programRequirements = window.programRequirements || { buckets: [] };
+                window.programRequirements.buckets = [
+                  ...(window.programRequirements.buckets || []),
+                  ...result.new_requirements.buckets,
+                ];
+              }
 
               // 3. Grid Placement Algorithm
               let maxX = -Infinity;

--- a/static/js/program_handler.js
+++ b/static/js/program_handler.js
@@ -90,8 +90,8 @@ export function setupAddProgramButton(
               let currentY = startY;
 
               Object.keys(result.new_details).forEach((code, index) => {
-                if (!nodes.get(code)) {
-                  const d = result.new_details[code];
+                const d = result.new_details[code];
+                if (!nodes.get(code) && (d.include_in_graph !== false)) {
                   const xOffset = currentX + Math.floor(index / 5) * 200;
                   const yOffset = currentY + (index % 5) * 150;
 

--- a/static/js/sheet_view.js
+++ b/static/js/sheet_view.js
@@ -1,4 +1,4 @@
-export function updateSheetView(detailsData) {
+export function updateSheetView(detailsData, requirementsData = window.programRequirements || {}) {
   let stats = {
     CORE: { taken: 0 },
     COMPLEMENTARY: { taken: 0 },
@@ -63,6 +63,60 @@ export function updateSheetView(detailsData) {
     const load = semesterLoads[term];
     const row = document.createElement("tr");
     row.innerHTML = `<td><strong>${term}</strong></td><td style="${load >= 18 ? "color: var(--error-text); font-weight: bold;" : ""}">${load}</td>`;
+    tbody.appendChild(row);
+  });
+
+  updateRequirementBuckets(detailsData, requirementsData);
+}
+
+function formatCreditRange(bucket) {
+  const minCredits = Number(bucket.min_credits) || 0;
+  const maxCredits = Number(bucket.max_credits);
+
+  if (Number.isFinite(maxCredits) && maxCredits !== minCredits) {
+    return `${minCredits}-${maxCredits}`;
+  }
+
+  return `${minCredits}`;
+}
+
+function updateRequirementBuckets(detailsData, requirementsData) {
+  const card = document.getElementById("requirementBucketsCard");
+  const tbody = document.getElementById("requirementBucketTableBody");
+  if (!card || !tbody) return;
+
+  const buckets = Array.isArray(requirementsData?.buckets)
+    ? requirementsData.buckets
+    : [];
+
+  if (buckets.length === 0) {
+    card.style.display = "none";
+    tbody.innerHTML = "";
+    return;
+  }
+
+  card.style.display = "block";
+  tbody.innerHTML = "";
+
+  buckets.forEach((bucket) => {
+    const taken = Object.entries(detailsData).reduce((sum, [code, course]) => {
+      const belongsToBucket =
+        course.requirement_bucket === bucket.id || bucket.courses?.includes(code);
+      const countsTowardProgress = ["DONE", "TAKING"].includes(course.status);
+      return belongsToBucket && countsTowardProgress
+        ? sum + (parseFloat(course.credits) || 0)
+        : sum;
+    }, 0);
+
+    const minCredits = Number(bucket.min_credits) || 0;
+    const remaining = Math.max(0, minCredits - taken);
+    const row = document.createElement("tr");
+    row.innerHTML = `
+      <td><strong>${bucket.title || bucket.id}</strong><br><small>${bucket.category || "CORE"}</small></td>
+      <td>${formatCreditRange(bucket)}</td>
+      <td>${taken}</td>
+      <td class="${remaining > 0 ? "bold-red" : ""}">${remaining}</td>
+    `;
     tbody.appendChild(row);
   });
 }

--- a/templates/graph.html
+++ b/templates/graph.html
@@ -48,6 +48,16 @@
       </div>
       <div id="courseNetwork"></div>
 
+      <div class="custom-manipulation-buttons">
+        <button id="hideSelectedOptionalBtn" type="button">Hide Selected Optional</button>
+        <div id="optionalCourseShelf" class="optional-shelf">
+          <h4 style="margin:0 0 6px 0;">Optional Course Pool</h4>
+          <div id="optionalCount" class="optional-count">0 optional courses hidden</div>
+          <div id="optionalCourseList" class="optional-course-list"></div>
+        </div>
+      </div>
+
+
       <div id="nodeInspector" class="node-inspector">
         <div class="inspector-header">
           <h4 id="inspectorCode">COMP 250</h4>
@@ -202,6 +212,21 @@
           </table>
         </div>
 
+        <div class="table-card" id="requirementBucketsCard" style="display: none;">
+          <h4>Requirement Buckets</h4>
+          <table class="styled-table">
+            <thead>
+              <tr>
+                <th>Bucket</th>
+                <th>Required</th>
+                <th>Taken/Taking</th>
+                <th>Remaining</th>
+              </tr>
+            </thead>
+            <tbody id="requirementBucketTableBody"></tbody>
+          </table>
+        </div>
+
         <div class="table-card">
           <h4>Per Semester Load</h4>
           <table class="styled-table">
@@ -238,6 +263,8 @@
 <script type="text/javascript">
   const prereqsData = {{ prereqs|tojson }};
   const detailsData = {{ details|tojson }};
+  const programRequirements = {{ requirements|default({})|tojson }};
+  window.programRequirements = programRequirements;
   const serverScheduleId = {{ session.get('schedule_id') | tojson | safe }};
 
   // 1. PULL the requirements from the Flask session (defaults to 0 if brand new)

--- a/templates/graph.html
+++ b/templates/graph.html
@@ -49,11 +49,9 @@
       <div id="courseNetwork"></div>
 
       <div class="custom-manipulation-buttons">
-        <button id="hideSelectedOptionalBtn" type="button">Hide Selected Optional</button>
-        <div id="optionalCourseShelf" class="optional-shelf">
-          <h4 style="margin:0 0 6px 0;">Optional Course Pool</h4>
-          <div id="optionalCount" class="optional-count">0 optional courses hidden</div>
-          <div id="optionalCourseList" class="optional-course-list"></div>
+                <div id="optionalCourseShelf" class="optional-shelf">
+          <h4 class="optional-shelf-title">Optional Course Pool</h4>
+                    <div id="optionalBucketList" class="optional-course-list"></div>
         </div>
       </div>
 


### PR DESCRIPTION
### Motivation

- Provide structured parsing of program requirement buckets from McGill program pages so requirements (buckets, course-to-bucket mapping, credit totals) can be displayed and tracked. 
- Allow optional/complementary/elective courses to be hidden from the main graph UI and managed via an "optional course pool" for easier graph curation. 
- Persist and merge requirement data when loading/saving or adding multiple programs to a graph so requirement info stays consistent across sessions.

### Description

- Added a new parser `scripts/Getting_Info_For_Major/program_requirements.py` that extracts requirement buckets, credit bounds, course lists, course->bucket mapping, and aggregated credit requirements from program page HTML. 
- Updated scraping flow: `get_courses_of_major` now fetches a BeautifulSoup `soup` via `get_program_soup`, extracts course codes, and provides `get_course_metadata_from_program_page` fallback metadata; `get_information_for_major.process_program_data` now calls `program_requirements.extract_program_requirements`, returns requirement data alongside prereqs and details, and annotates course details with bucket/category/min/max credit info. 
- In `app.py` added `rebuild_requirements_from_details` and `merge_program_requirements` helpers and wired program requirement data into the session for the main routes (`/`, `/graph`, `/add_program_to_graph`, `/load_graph`) so requirements are saved, merged, and rendered by templates. 
- Frontend/UI changes: added optional-course pool UI and requirement-buckets table in `templates/graph.html`, new stylesheet rules in `static/css/style.css`, new client module `static/js/optional_courses.js` that removes optional courses from the network and provides an add-back shelf, integrated shelf initialization in `static/js/main.js`, updated `static/js/program_handler.js` to merge incoming requirement buckets into `window.programRequirements`, and extended `static/js/sheet_view.js` to render requirement bucket progress. 

### Testing

- No automated tests were added or modified in this change, and there were no repository automated test suites invoked by this rollout.
- Manual smoke validation was used during development to ensure the parser produces sensible bucket structures and that the UI components render without JS errors (not part of automated tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b4fff67e88323a57b5760b0180e6a)